### PR TITLE
Updated JIRA to 8.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV JIRA_HOME=/var/jira
 
 # Install JIRA including MySQL connector according to
 # https://confluence.atlassian.com/adminjiraserver/installing-jira-applications-on-linux-from-archive-file-938846844.html
-RUN VERSION=8.2.2 && \
+RUN VERSION=8.2.3 && \
     MYSQL_CONNECTOR_VERSION=5.1.47 && \
     mkdir $JIRA_INSTALL $JIRA_HOME && \
     wget https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-$VERSION.tar.gz -O /tmp/jira.tar.gz && \


### PR DESCRIPTION
There is a critical issue in JIRA that requires us to upgrade as soon as possible:
https://community.atlassian.com/t5/Jira-articles/CVE-2019-11581-Critical-Security-Advisory-for-Jira-Server-and/ba-p/1128241